### PR TITLE
Add protobuf definition for client->server CameraUpdate message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Protobuf
+*.pb.go

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # marshall-cam
-Hello world
-Hello Fred Chan!
-Goodbye!
+
+## Protobuf
+Protobuf definition files are in `/protocol`.
+
+To compile for Go, run from the project root:
+```bash
+protoc ./protocol/cameraupdate.proto --go_out=.
+```

--- a/protocol/cameraupdate.proto
+++ b/protocol/cameraupdate.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+package marshallcam;
+
+option go_package = "/server";
+
+/**
+ * CameraUpdate is sent from the client to server when new sensor data is
+ * available
+ */
+message CameraUpdate {
+    // Authentication token for this message
+    string api_token = 1;
+
+    // Unix time/seconds since Jan 1, 1970 UTC
+    uint64 time = 2;
+
+    float humidity = 3;
+    float temp = 4;
+
+    bytes picture = 5;
+}


### PR DESCRIPTION
The `CameraUpdate` message contains data that will be sent from the client to the server to update the server with new sensor data. This PR defines the message and its fields using Protobuf. This PR closes issue #6.

`cameraupdate.proto` can be compiled into helper code for writing/reading CameraUpdate messages. On the ESP32 side, we'll want to use [nanopb](https://github.com/nanopb/nanopb) to compile to a C source file and header.

Device ID is **not** sent with this message. The server will infer the device ID by its API key. When a new device is provisioned, the server should be updated with its API key.

The types of `humidity` and `temp` have been changed to `float`, in order to match the type of `readTemperature()` and `readHumidity()` in the [Adafruit DHT sensor library](https://adafruit.github.io/DHT-sensor-library/html/class_d_h_t.html#a68be09105aa7d831bb473c9d774918cf).